### PR TITLE
DryerProgramState End

### DIFF
--- a/custom_components/candy/client/model.py
+++ b/custom_components/candy/client/model.py
@@ -83,7 +83,7 @@ class DryerProgramState(Enum):
         elif self == DryerProgramState.RUNNING:
             return "Running"
         elif self == DryerProgramState.END:
-            Return "End"
+            return "End"
         else:
             return "%s" % self
 


### PR DESCRIPTION
I just noticed that the tumble dryer is going for few minutes when its cycle is finished to PrPh -> 3. So I called it END and added to Program State. Otherwise we lost the sensor for that amount of time.