### PR TITLE
Rate limit API requests

### DIFF
--- a/custom_components/candy/manifest.json
+++ b/custom_components/candy/manifest.json
@@ -6,7 +6,8 @@
   "documentation": "https://github.com/ofalvai/home-assistant-candy",
   "issue_tracker": "https://github.com/ofalvai/home-assistant-candy/issues",
   "requirements": [
-    "backoff>=2.0"
+    "backoff~=2.0",
+    "aiolimiter~=1.0"
   ],
   "ssdp": [],
   "zeroconf": [],

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,5 @@ pytest~=7.1
 pytest-homeassistant-custom-component==0.12.18
 
 # Component dependencies
-backoff==2.2.1
+backoff~=2.0
+aiolimiter~=1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 # See here for more info: https://docs.pytest.org/en/latest/fixture.html (note that
 # pytest includes fixtures OOB which you can use as defined on this page)
 from unittest.mock import patch
+from aiolimiter import AsyncLimiter
 
 import pytest
 
@@ -38,3 +39,8 @@ def skip_notifications_fixture():
         "homeassistant.components.persistent_notification.async_dismiss"
     ):
         yield
+
+@pytest.fixture(name="disable_api_rate_limiter", autouse=True)
+def disable_api_rate_limiter():
+    with patch("custom_components.candy.client._LIMITER"):
+        yield AsyncLimiter(max_rate=1000, time_period=1)


### PR DESCRIPTION
Add a global rate limiter for any API request the integration makes. Some devices can't handle too frequent requests and respond with BAD_REQUEST.

This solves some (but not all!) issues reported in #61, #53