### PR TITLE
Remove division by 60 in the remaining time sensor

### DIFF
--- a/custom_components/candy/client/model.py
+++ b/custom_components/candy/client/model.py
@@ -65,7 +65,7 @@ class WashingMachineStatus:
             program_code=int(json["PrCode"]) if "PrCode" in json else None,
             temp=int(json["Temp"]),
             spin_speed=int(json["SpinSp"]) * 100,
-            remaining_minutes=round(int(json["RemTime"]) / 60),
+            remaining_minutes=round(int(json["RemTime"])),
             remote_control=json["WiFiStatus"] == "1",
             fill_percent=int(json["FillR"]) if "FillR" in json else None
         )


### PR DESCRIPTION
To correctly display the time, you need to remove the division by 60 in the remaining time sensor.
Even if the number of minutes will display more than 60 - Home Assistant seems to be able to automatically recalculate them into the usual human-readable form. And even if it's not, it's more informative to see a value like 95 min than just 2 min.