### PR TITLE
Code update for the Deprecation of 2 constants

### DIFF
--- a/custom_components/candy/sensor.py
+++ b/custom_components/candy/sensor.py
@@ -3,7 +3,7 @@ from typing import Any, Mapping
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS, TIME_MINUTES
+from homeassistant.const import UnitOfTemperature.CELSIUS, TIME_MINUTES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import StateType
@@ -350,7 +350,7 @@ class CandyOvenTempSensor(CandyBaseSensor):
 
     @property
     def unit_of_measurement(self) -> str:
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def icon(self) -> str:

--- a/custom_components/candy/sensor.py
+++ b/custom_components/candy/sensor.py
@@ -3,7 +3,7 @@ from typing import Any, Mapping
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature.CELSIUS, TIME_MINUTES
+from homeassistant.const import UnitOfTemperature.CELSIUS, UnitOfTime.MINUTES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import StateType
@@ -171,7 +171,7 @@ class CandyWashRemainingTimeSensor(CandyBaseSensor):
 
     @property
     def unit_of_measurement(self) -> str:
-        return TIME_MINUTES
+        return UnitOfTime.MINUTES
 
     @property
     def icon(self) -> str:


### PR DESCRIPTION
- TEMP_CELSIUS was used from candy, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead

   - **Replaced both instances within the code**

- TIME_MINUTES was used from candy, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTime.MINUTES instead

   - **Replaced both instances within the code**